### PR TITLE
allow to send files from commands and filters 

### DIFF
--- a/examples/deltabot_echo/deltabot_echo.py
+++ b/examples/deltabot_echo/deltabot_echo.py
@@ -10,7 +10,7 @@ def deltabot_init(bot):
     bot.commands.register(name="/echo", func=process_command_echo)
 
 
-def process_command_echo(command):
+def process_command_echo(command, replies):
     """ Echoes back received message.
 
     To use it you can simply send a message starting with
@@ -19,7 +19,7 @@ def process_command_echo(command):
     message = command.message
     contact = message.get_sender_contact()
     sender = 'From: {} <{}>'.format(contact.display_name, contact.addr)
-    return "{}\n{!r}".format(sender, command.payload)
+    replies.add(text="{}\n{!r}".format(sender, command.payload))
 
 
 def test_mock_echo(mocker):

--- a/examples/mycalc.py
+++ b/examples/mycalc.py
@@ -12,7 +12,7 @@ def deltabot_init(bot):
     )
 
 
-def process_command_mycalc(command):
+def process_command_mycalc(command, replies):
     """caculcates result of arithmetic integer expression.
 
     send "/mycalc 23+20" to the bot to get the result "43" back
@@ -30,7 +30,7 @@ def process_command_mycalc(command):
         # now it's safe to use eval
         reply = "result of {!r}: {}".format(text, eval(text))
 
-    return reply
+    replies.add(text=reply)
 
 
 class TestMyCalc:

--- a/src/deltabot/bot.py
+++ b/src/deltabot/bot.py
@@ -234,6 +234,7 @@ class IncomingEventHandler:
     def stop(self):
         self._running = False
         self._needs_check.set()
+        self._thread.join(timeout=10)
 
     def event_worker(self):
         self.logger.debug("event-worker startup")

--- a/src/deltabot/bot.py
+++ b/src/deltabot/bot.py
@@ -278,7 +278,7 @@ class Replies:
         self.logger = logger
         self._replies = []
 
-    def add(self, text=None, filename=None, bytefile=None):
+    def add(self, text=None, filename=None, bytefile=None, chat=None):
         """ Add a text or file-based reply. """
         if bytefile:
             if not filename:
@@ -286,7 +286,7 @@ class Replies:
             if os.path.basename(filename) != filename:
                 raise ValueError("if bytefile is specified, filename must a basename, not path")
 
-        self._replies.append((text, filename, bytefile))
+        self._replies.append((text, filename, bytefile, chat))
 
     def send_reply_messages(self):
         tempdir = tempfile.mkdtemp() if any(x[2] for x in self._replies) else None
@@ -302,7 +302,7 @@ class Replies:
         return l
 
     def _send_replies_to_core(self, tempdir):
-        for text, filename, bytefile in self._replies:
+        for text, filename, bytefile, chat in self._replies:
             if bytefile:
                 # XXX avoid double copy -- core will copy this file another time
                 # XXX maybe also avoid loading the file into RAM but it's max 50MB
@@ -319,7 +319,9 @@ class Replies:
                 msg.set_text(text)
             if filename is not None:
                 msg.set_file(filename)
-            msg = self.incoming_message.chat.send_msg(msg)
+            if chat is None:
+                chat = self.incoming_message.chat
+            msg = chat.send_msg(msg)
             yield msg
 
         self._replies[:] = []

--- a/src/deltabot/builtin/settings.py
+++ b/src/deltabot/builtin/settings.py
@@ -62,10 +62,10 @@ class db_list:
             out.line("{}: {}".format(key, res))
 
 
-def command_set(command):
-    """show all/one settings or set one particular setting.
+def command_set(command, replies):
+    """show all/one per-peer settings or set a value for a setting.
 
-    examples:
+    Examples:
 
     # show all settings
     /set
@@ -78,16 +78,17 @@ def command_set(command):
     """
     addr = command.message.get_sender_contact().addr
     if not command.payload:
-        return "\n".join(dump_settings(command.bot, scope=addr))
-    if "=" in command.payload:
+        text = "\n".join(dump_settings(command.bot, scope=addr))
+    elif "=" in command.payload:
         name, value = command.payload.split("=", 1)
         name = name.strip()
         value = value.strip()
         old = command.bot.set(name, value, scope=addr)
-        return "old: {}={}".format(name, repr(old))
-
-    x = command.bot.get(command.args[0], scope=addr)
-    return "{}={}".format(command.args[0], x)
+        text = "old: {}={}\nnew: {}={}".format(name, repr(old), name, repr(value))
+    else:
+        x = command.bot.get(command.args[0], scope=addr)
+        text = "{}={}".format(command.args[0], x)
+    replies.add(text=text)
 
 
 def dump_settings(bot, scope):

--- a/src/deltabot/commands.py
+++ b/src/deltabot/commands.py
@@ -1,4 +1,5 @@
 
+import inspect
 from collections import OrderedDict
 
 
@@ -20,7 +21,7 @@ class Commands:
         self.bot.plugins.add_module("commands", self)
 
     def register(self, name, func):
-        short, long = parse_command_docstring(func)
+        short, long = parse_command_docstring(func, args=["command", "replies"])
         cmd_def = CommandDef(name, short=short, long=long, func=func)
         if name in self._cmd_defs:
             raise ValueError("command {!r} already registered".format(name))
@@ -106,10 +107,14 @@ class IncomingCommand:
         return self.payload.split()
 
 
-def parse_command_docstring(func):
+def parse_command_docstring(func, args):
     description = func.__doc__
     if not description:
         raise ValueError("command {!r} needs to have a docstring".format(func))
+    funcargs = set(inspect.getargs(func.__code__).args)
+    for arg in args:
+        if arg not in funcargs:
+            raise ValueError("{!r} needs to accept {!r} argument".format(func, arg))
 
     lines = description.strip().split("\n")
     return lines.pop(0), "\n".join(lines).strip()

--- a/src/deltabot/commands.py
+++ b/src/deltabot/commands.py
@@ -49,17 +49,20 @@ class Commands:
         payload = parts[0] if parts else ""
         cmd = IncomingCommand(bot=self.bot, cmd_def=cmd_def, payload=payload, message=message)
         self.bot.logger.info("processing command {}".format(cmd))
-        res = cmd.cmd_def.func(cmd)
-        if res:
-            replies.add(text=res)
-            return True
+        try:
+            res = cmd.cmd_def.func(command=cmd, replies=replies)
+        except Exception as ex:
+            self.logger.exception(ex)
+        else:
+            assert res is None, res
+        return True
 
     @deltabot_hookimpl
     def deltabot_init(self, bot):
         assert bot == self.bot
         self.register("/help", self.command_help)
 
-    def command_help(self, command):
+    def command_help(self, command, replies):
         """ reply with help message about available commands. """
         l = []
         l.append("**commands**")
@@ -69,7 +72,7 @@ class Commands:
         pm = self.bot.plugins._pm
         plugins = [pm.get_name(plug) for plug, dist in pm.list_plugin_distinfo()]
         l.append("enabled plugins: {}".format(" ".join(plugins)))
-        return "\n".join(l)
+        replies.add(text="\n".join(l))
 
 
 class CommandDef:

--- a/src/deltabot/filters.py
+++ b/src/deltabot/filters.py
@@ -30,9 +30,8 @@ class Filters:
     def deltabot_incoming_message(self, message, replies):
         for name, filter_def in self._filter_defs.items():
             self.logger.debug("calling filter {!r} on message id={}".format(name, message.id))
-            res = filter_def.func(message)
-            if res:
-                replies.add(text=res)
+            res = filter_def.func(message=message, replies=replies)
+            assert res is None
 
 
 class FilterDef:

--- a/src/deltabot/filters.py
+++ b/src/deltabot/filters.py
@@ -13,7 +13,7 @@ class Filters:
         self.bot.plugins.add_module("filters", self)
 
     def register(self, name, func):
-        short, long = parse_command_docstring(func)
+        short, long = parse_command_docstring(func, args=["message", "replies"])
         cmd_def = FilterDef(name, short=short, long=long, func=func)
         if name in self._filter_defs:
             raise ValueError("filter {!r} already registered".format(name))

--- a/src/deltabot/pytestplugin.py
+++ b/src/deltabot/pytestplugin.py
@@ -67,9 +67,9 @@ def mocker(mock_bot):
 
         def run_command(self, text):
             msg = self.make_incoming_message(text)
-            replies = Replies(msg)
+            replies = Replies(msg, self.bot.logger)
             self.bot.commands.deltabot_incoming_message(message=msg, replies=replies)
-            l = replies.send_reply_messages(self.bot.logger)
+            l = replies.send_reply_messages()
             if not l:
                 raise ValueError("no reply for command {!r}".format(text))
             if len(l) > 1:

--- a/src/deltabot/pytestplugin.py
+++ b/src/deltabot/pytestplugin.py
@@ -67,9 +67,9 @@ def mocker(mock_bot):
 
         def run_command(self, text):
             msg = self.make_incoming_message(text)
-            replies = Replies(self.account)
+            replies = Replies(msg)
             self.bot.commands.deltabot_incoming_message(message=msg, replies=replies)
-            l = list(replies.get_reply_messages())
+            l = replies.send_reply_messages(self.bot.logger)
             if not l:
                 raise ValueError("no reply for command {!r}".format(text))
             if len(l) > 1:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,14 +6,14 @@ from deltabot.commands import parse_command_docstring
 
 def test_parse_command_docstring():
     with pytest.raises(ValueError):
-        parse_command_docstring(lambda: None)
+        parse_command_docstring(lambda: None, args=[])
 
-    def func(command):
+    def func(command, replies):
         """short description.
 
         long description.
         """
-    short, long = parse_command_docstring(func)
+    short, long = parse_command_docstring(func, args="command replies".split())
     assert short == "short description."
     assert long == "long description."
 
@@ -23,8 +23,16 @@ def test_run_help(mocker):
     assert "/help" in reply.text
 
 
-def test_register(mock_bot):
+def test_fail_args(mock_bot):
     def my_command(command):
+        """ invalid """
+
+    with pytest.raises(ValueError):
+        mock_bot.commands.register(name="/example", func=my_command)
+
+
+def test_register(mock_bot):
+    def my_command(command, replies):
         """ my commands example. """
 
     mock_bot.commands.register(name="/example", func=my_command)

--- a/tests/test_deltabot.py
+++ b/tests/test_deltabot.py
@@ -89,3 +89,18 @@ class TestReplies:
         assert "something" in l[0].filename
         s = open(l[0].filename, "rb").read()
         assert s == b"bytecontent"
+
+    def test_chat_incoming_default(self, replies):
+        replies.add(text="hello")
+        l = replies.send_reply_messages()
+        assert len(l) == 1
+        assert l[0].text == "hello"
+        assert l[0].chat == replies.incoming_message.chat
+
+    def test_different_chat(self, replies, mock_bot):
+        chat = mock_bot.account.create_group_chat("new group")
+        replies.add(text="this", chat=chat)
+        l = replies.send_reply_messages()
+        assert len(l) == 1
+        assert l[0].text == "this"
+        assert l[0].chat.id == chat.id

--- a/tests/test_deltabot.py
+++ b/tests/test_deltabot.py
@@ -1,4 +1,6 @@
 
+import io
+
 from deltabot.bot import Replies
 
 
@@ -50,22 +52,36 @@ class TestSettings:
 
 
 class TestReplies:
-    def test_two_text(self, mock_bot):
-        r = Replies(mock_bot.account)
+    def test_two_text(self, mock_bot, mocker):
+        incoming_message = mocker.make_incoming_message("0")
+        r = Replies(incoming_message)
         r.add(text="hello")
         r.add(text="world")
-        l = list(r.get_reply_messages())
+        l = r.send_reply_messages(mock_bot.logger)
         assert len(l) == 2
         assert l[0].text == "hello"
         assert l[1].text == "world"
 
-    def test_file(self, mock_bot, tmpdir):
+    def test_filename(self, mock_bot, mocker, tmpdir):
         p = tmpdir.join("textfile")
         p.write("content")
-        r = Replies(mock_bot.account)
+        r = Replies(mocker.make_incoming_message("0"))
         r.add(text="hello", filename=p.strpath)
-        l = list(r.get_reply_messages())
+        l = r.send_reply_messages(mock_bot.logger)
         assert len(l) == 1
         assert l[0].text == "hello"
         s = open(l[0].filename).read()
         assert s == "content"
+
+    def test_file_content(self, mock_bot, mocker):
+        r = Replies(mocker.make_incoming_message("0"))
+        bytefile = io.BytesIO(b'bytecontent')
+        r.add(text="hello", filename="something.txt", bytefile=bytefile)
+
+        l = r.send_reply_messages(mock_bot.logger)
+        assert len(l) == 1
+        assert l[0].text == "hello"
+        assert l[0].filename.endswith(".txt")
+        assert "something" in l[0].filename
+        s = open(l[0].filename, "rb").read()
+        assert s == b"bytecontent"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2,10 +2,12 @@
 import pytest
 
 
-def hitchhiker(message):
+def hitchhiker(message, replies):
     """ my incoming message filter example. """
     if "42" in message.text:
-        return "correct answer!"
+        replies.add(text="correct answer!")
+    else:
+        replies.add(text="try again!")
 
 
 def test_register(mock_bot):
@@ -21,3 +23,5 @@ def test_simple_filter(bot_tester):
     bot_tester.bot.filters.register(name="hitchhiker", func=hitchhiker)
     msg_reply = bot_tester.send_command("hello 42")
     assert msg_reply.text == "correct answer!"
+    msg_reply = bot_tester.send_command("hello 10")
+    assert msg_reply.text == "try again!"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -25,3 +25,19 @@ def test_simple_filter(bot_tester):
     assert msg_reply.text == "correct answer!"
     msg_reply = bot_tester.send_command("hello 10")
     assert msg_reply.text == "try again!"
+
+
+def test_pseudo_downloader(bot_tester):
+    def downloader(message, replies):
+        """ pseudo downloader of https"""
+        if "https" in message.text:
+            fn = __file__
+            replies.add(text="downloaded", filename=__file__)
+
+    bot_tester.bot.filters.register(name="downloader", func=downloader)
+    msg_reply = bot_tester.send_command("this https://qwjkeqwe")
+    assert msg_reply.text == "downloaded"
+    assert msg_reply.filename != __file__  # blobdir
+    with open(msg_reply.filename) as f:
+        content = f.read()
+    assert content == open(__file__).read()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -31,7 +31,6 @@ def test_pseudo_downloader(bot_tester):
     def downloader(message, replies):
         """ pseudo downloader of https"""
         if "https" in message.text:
-            fn = __file__
             replies.add(text="downloaded", filename=__file__)
 
     bot_tester.bot.filters.register(name="downloader", func=downloader)


### PR DESCRIPTION
Fixes #17 -- command and filter functions now need to accept a "replies" object which now presents the only way to trigger replies. 

`replies.add()` now accepts text, filename, bytefile and chat with most of the params being optional. 

Note that if bytefile is a stream, then filename needs to be a "basename" which will be used as a suggested name -- the core will modify it but usually leave prefix and suffix the same.  
