### PR TITLE
Don't run filters if a command registered a reply already

### DIFF
--- a/src/deltabot/filters.py
+++ b/src/deltabot/filters.py
@@ -26,7 +26,7 @@ class Filters:
     def dict(self):
         return self._filter_defs.copy()
 
-    @deltabot_hookimpl
+    @deltabot_hookimpl(trylast=True)
     def deltabot_incoming_message(self, message, replies):
         for name, filter_def in self._filter_defs.items():
             self.logger.debug("calling filter {!r} on message id={}".format(name, message.id))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -27,6 +27,18 @@ def test_simple_filter(bot_tester):
     assert msg_reply.text == "try again!"
 
 
+def test_filters_not_called_on_commands(bot_tester):
+    l = []
+
+    def always_answer(message, replies):
+        """ always"""
+        l.append(1)
+
+    bot_tester.bot.filters.register(name="always_answer", func=always_answer)
+    bot_tester.send_command("/help 42")
+    assert not l
+
+
 def test_pseudo_downloader(bot_tester):
     def downloader(message, replies):
         """ pseudo downloader of https"""


### PR DESCRIPTION
let filters run last so that if there was a command (or some other incoming hook impl) that provided final answers (by returning true) the filter will not be called anymore.

fix #15 
obsoletes/closes #22