### PR TITLE
don't send command not found errors to group chat

### DIFF
--- a/src/deltabot/bot.py
+++ b/src/deltabot/bot.py
@@ -278,6 +278,9 @@ class Replies:
         self.logger = logger
         self._replies = []
 
+    def has_replies(self):
+        return bool(self._replies)
+
     def add(self, text=None, filename=None, bytefile=None, chat=None):
         """ Add a text or file-based reply. """
         if bytefile:

--- a/src/deltabot/commands.py
+++ b/src/deltabot/commands.py
@@ -61,7 +61,8 @@ class Commands:
         else:
             reply = "unknown command {!r}".format(orig_cmd_name)
             self.logger.warn(reply)
-            replies.add(text=reply)
+            if not message.chat.is_group():
+                replies.add(text=reply)
             return True
 
         cmd = IncomingCommand(bot=self.bot, cmd_def=cmd_def, message=message,

--- a/src/deltabot/pytestplugin.py
+++ b/src/deltabot/pytestplugin.py
@@ -56,12 +56,15 @@ def mocker(mock_bot):
             self.bot = mock_bot
             self.account = mock_bot.account
 
-        def make_incoming_message(self, text, addr="Alice <alice@example.org>"):
+        def make_incoming_message(self, text, group=False, addr="Alice <alice@example.org>"):
             msg = Message.new_empty(self.account, "text")
             msg.set_text(text)
             name, routeable_addr = parseaddr(addr)
             contact = self.account.create_contact(routeable_addr, name=name)
-            chat = self.account.create_chat(contact)
+            if group:
+                chat = self.account.create_group_chat("mockgroup", contacts=[contact])
+            else:
+                chat = self.account.create_chat(contact)
             msg_in = chat.prepare_message(msg)
             return msg_in
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -91,18 +91,18 @@ class TestArgParsing:
         assert command.args == ["123", "456"]
         assert command.payload == "123 456"
 
-    def test_under_conflict(self, parse_cmd, mock_bot):
+    def test_under_conflict(self, parse_cmd):
         parse_cmd("/some", "/some")
         with pytest.raises(ValueError):
             parse_cmd("/some_group_long", "")
         with pytest.raises(ValueError):
             parse_cmd("/some_group", "")
 
-    def test_under_conflict2(self, parse_cmd, mock_bot):
+    def test_under_conflict2(self, parse_cmd):
         parse_cmd("/some_group", "/some_group")
         with pytest.raises(ValueError):
             parse_cmd("/some", "")
 
-    def test_two_commands_with_different_subparts(self, parse_cmd, mock_bot):
+    def test_two_commands_with_different_subparts(self, parse_cmd):
         assert parse_cmd("/some_group", "/some_group").cmd_def.cmd == "/some_group"
         assert parse_cmd("/some_other", "/some_other").cmd_def.cmd == "/some_other"

--- a/tests/test_deltabot.py
+++ b/tests/test_deltabot.py
@@ -54,7 +54,6 @@ class TestSettings:
 
 
 class TestReplies:
-
     @pytest.fixture
     def replies(self, mock_bot, mocker):
         incoming_message = mocker.make_incoming_message("0")


### PR DESCRIPTION
only send errors if you are in a 1:1 group chat. 
closes #21 
fixes #20 (modulo mentions) 